### PR TITLE
Use 'imt' in window title

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ def calculate_bmi():
 
 
 root = tk.Tk()
-root.title("Калькулятор ІМТ")
+root.title("Калькулятор imt")
 root.geometry("300x250")
 root.configure(bg="white")
 


### PR DESCRIPTION
Replace the Cyrillic uppercase 'ІМТ' with the Latin lowercase 'imt' in the main window title (Калькулятор imt). This standardizes the title and avoids potential character/encoding or stylistic inconsistencies.